### PR TITLE
VBR Crash Fix

### DIFF
--- a/Source/API/EbErrorCodes.h
+++ b/Source/API/EbErrorCodes.h
@@ -202,6 +202,7 @@ typedef enum ENCODER_ERROR_CODES
     EB_ENC_RC_ERROR5                    = 0x1404, 
     EB_ENC_RC_ERROR6                    = 0x1405,
     EB_ENC_RC_ERROR7                    = 0x1406,
+    EB_ENC_RC_ERROR8                    = 0x1407,
 
     //EB_ENC_PU_ERRORS                  = 0x1500,
     EB_ENC_PU_ERROR1                    = 0x1500,

--- a/Source/App/EbAppProcessCmd.c
+++ b/Source/App/EbAppProcessCmd.c
@@ -1306,6 +1306,10 @@ static void LogErrorOutput(
     case EB_ENC_RC_ERROR7:
         fprintf(errorLogFile, "Error: remainingBytes has to be multiple of 2 for 16 bit input\n");
         break;
+        
+    case EB_ENC_RC_ERROR8:
+        fprintf(errorLogFile, "Error: hlRateControlHistorgramQueue Overflow\n");
+        break;
 
         // EB_ENC_RD_COST_ERRORS:
     case EB_ENC_RD_COST_ERROR1:

--- a/Source/Lib/System/EbInitialRateControlProcess.c
+++ b/Source/Lib/System/EbInitialRateControlProcess.c
@@ -850,7 +850,7 @@ void UpdateHistogramQueueEntry(
 	HlRateControlHistogramEntry_t     *histogramQueueEntryPtr;
 	EB_S32                             histogramQueueEntryIndex;
 
-	EbBlockOnMutex(sequenceControlSetPtr->encodeContextPtr->rateTableUpdateMutex);
+	EbBlockOnMutex(sequenceControlSetPtr->encodeContextPtr->hlRateControlHistorgramQueueMutex);
 
 	histogramQueueEntryIndex = (EB_S32)(pictureControlSetPtr->pictureNumber - encodeContextPtr->hlRateControlHistorgramQueue[encodeContextPtr->hlRateControlHistorgramQueueHeadIndex]->pictureNumber);
 	histogramQueueEntryIndex += encodeContextPtr->hlRateControlHistorgramQueueHeadIndex;
@@ -861,7 +861,7 @@ void UpdateHistogramQueueEntry(
 	histogramQueueEntryPtr->lifeCount += pictureControlSetPtr->historgramLifeCount;
 	histogramQueueEntryPtr->passedToHlrc = EB_TRUE;
 
-	EbReleaseMutex(sequenceControlSetPtr->encodeContextPtr->rateTableUpdateMutex);
+	EbReleaseMutex(sequenceControlSetPtr->encodeContextPtr->hlRateControlHistorgramQueueMutex);
 
 	return;
 

--- a/Source/Lib/System/EbInitialRateControlProcess.c
+++ b/Source/Lib/System/EbInitialRateControlProcess.c
@@ -17,6 +17,7 @@
 #include "EbUtility.h"
 #include "EbReferenceObject.h"
 #include "EbMotionEstimation.h"
+#include "EbErrorCodes.h"
 
 /**************************************
 * Macros
@@ -857,10 +858,10 @@ void UpdateHistogramQueueEntry(
 	histogramQueueEntryIndex = (histogramQueueEntryIndex > HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH - 1) ?
 		histogramQueueEntryIndex - HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
 		histogramQueueEntryIndex;
+    CHECK_REPORT_ERROR(histogramQueueEntryIndex >= 0, encodeContextPtr->appCallbackPtr, EB_ENC_RC_ERROR8);
 	histogramQueueEntryPtr = encodeContextPtr->hlRateControlHistorgramQueue[histogramQueueEntryIndex];
 	histogramQueueEntryPtr->lifeCount += pictureControlSetPtr->historgramLifeCount;
 	histogramQueueEntryPtr->passedToHlrc = EB_TRUE;
-
 	EbReleaseMutex(sequenceControlSetPtr->encodeContextPtr->hlRateControlHistorgramQueueMutex);
 
 	return;

--- a/Source/Lib/System/EbPictureControlSet.h
+++ b/Source/Lib/System/EbPictureControlSet.h
@@ -387,7 +387,7 @@ typedef struct PictureParentControlSet_s
     EB_BOOL                               sceneChangeInGop;
     // used for Look ahead
     EB_U8                                 framesInSw;
-    EB_S8                                 historgramLifeCount;
+    EB_S16                                historgramLifeCount;
 
     EB_BOOL                               qpOnTheFly;
 


### PR DESCRIPTION
- Fixed crash due to hlRateControlHistorgramQueue overflow
- Fixed UpdateHistogramQueueEntry() function locking on the wrong mutex