### PR TITLE
Support reading from pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ In order to run the highest resolution supported by the encoder, at least 64GB o
 	-	On any of the Windows* Operating Systems listed in the OS requirements section, install Visual Studio 2017
 	-	Once the installation is complete, copy the binaries to a location making sure that both the sample application “ebHevcEncApp.exe” and library “ebHevcEncLib.dll” are in the same folder.
 	-	Open the command prompt window at the chosen location and run the sample application to encode.
-	-	Sample application supports reading from pipe. E.g. ffmpeg -i [input.mp4] -nostdin -f rawvideo -pix_fmt yuv420p - | ebHevcEncApp.exe -i stdin -n [number_of_frames_to_encode].
+	-	Sample application supports reading from pipe. E.g. ffmpeg -i [input.mp4] -nostdin -f rawvideo -pix_fmt yuv420p - | ebHevcEncApp.exe -i stdin -n [number_of_frames_to_encode] -w [width] -h [height].
 
 ## Linux* Operating Systems (64-bit):
 
@@ -128,7 +128,7 @@ For the binaries to operate properly on your system, the following conditions ha
 	-	Change the permissions on the sample application “HevcEncoderApp” executable by running the command: 				chmod +x HevcEncoderApp
 	-	cd into your chosen location
 	-	Run the sample application to encode.
-	-	Sample application supports reading from pipe. E.g. ffmpeg -i [input.mp4] -nostdin -f rawvideo -pix_fmt yuv420p - | ./HevcEncoderApp -i stdin -n [number_of_frames_to_encode].
+	-	Sample application supports reading from pipe. E.g. ffmpeg -i [input.mp4] -nostdin -f rawvideo -pix_fmt yuv420p - | ./HevcEncoderApp -i stdin -n [number_of_frames_to_encode] -w [width] -h [height].
 
 # Demo features and limitations
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-
+﻿
 # Scalable Video Technology for HEVC Encoder (SVT-HEVC Encoder)
 
 The Scalable Video Technology for HEVC Encoder (SVT-HEVC Encoder) is an HEVC-compliant encoder library core that achieves excellent density-quality tradeoffs, and is highly optimized for Intel® Xeon™ Scalable Processor and Xeon™ D processors.
@@ -105,6 +105,7 @@ In order to run the highest resolution supported by the encoder, at least 64GB o
 	-	On any of the Windows* Operating Systems listed in the OS requirements section, install Visual Studio 2017
 	-	Once the installation is complete, copy the binaries to a location making sure that both the sample application “ebHevcEncApp.exe” and library “ebHevcEncLib.dll” are in the same folder.
 	-	Open the command prompt window at the chosen location and run the sample application to encode.
+	-	Sample application supports reading from pipe. E.g. ffmpeg -i [input.mp4] -nostdin -f rawvideo -pix_fmt yuv420p - | ebHevcEncApp.exe -i stdin -n [number_of_frames_to_encode].
 
 ## Linux* Operating Systems (64-bit):
 
@@ -127,6 +128,7 @@ For the binaries to operate properly on your system, the following conditions ha
 	-	Change the permissions on the sample application “HevcEncoderApp” executable by running the command: 				chmod +x HevcEncoderApp
 	-	cd into your chosen location
 	-	Run the sample application to encode.
+	-	Sample application supports reading from pipe. E.g. ffmpeg -i [input.mp4] -nostdin -f rawvideo -pix_fmt yuv420p - | ./HevcEncoderApp -i stdin -n [number_of_frames_to_encode].
 
 # Demo features and limitations
 

--- a/Source/App/EbAppConfig.c
+++ b/Source/App/EbAppConfig.c
@@ -115,7 +115,7 @@
  **********************************/
 static void SetCfgInputFile                     (const char *value, EbConfig_t *cfg) 
 {
-    if (cfg->inputFile){ if (cfg->inputFile == stdin) cfg->inputFile = (FILE*)NULL; else fclose(cfg->inputFile); }cfg->inputFile = fopen(value, "rb");
+    if (cfg->inputFile && cfg->inputFile != stdin) fclose(cfg->inputFile); if (!strcmp(value, "stdin")) cfg->inputFile = stdin; else cfg->inputFile = fopen(value, "rb");
 };
 static void SetCfgStreamFile                    (const char *value, EbConfig_t *cfg) 
 {
@@ -526,7 +526,7 @@ void EbConfigDtor(EbConfig_t *configPtr)
     }
 
     if (configPtr->inputFile) {
-        fclose(configPtr->inputFile);
+        if (configPtr->inputFile != stdin) fclose(configPtr->inputFile);
         configPtr->inputFile = (FILE *) NULL;
     }
 

--- a/Source/App/EbAppMain.c
+++ b/Source/App/EbAppMain.c
@@ -25,6 +25,10 @@
 #include <Windows.h>
 #endif
 
+#ifdef _MSC_VER
+#include <io.h>     /* _setmode() */
+#include <fcntl.h>  /* _O_BINARY */
+#endif
 
 /***************************************
  * External Functions
@@ -64,6 +68,10 @@ void AssignAppThreadGroup(EB_U8 targetSocket) {
  ***************************************/
 int main(int argc, char* argv[])
 {
+#ifdef _MSC_VER
+    _setmode(_fileno(stdin), _O_BINARY);
+    _setmode(_fileno(stdout), _O_BINARY);
+#endif
     EB_ERRORTYPE           return_error    = EB_ErrorNone;            // Error Handling
     APPEXITCONDITIONTYPE    exitCondition   = APP_ExitConditionNone;    // Processing loop exit condition
 


### PR DESCRIPTION
For linux OS, add support to read from pipe.
Sample app expects FrameToBeEncoded(-n) to be set.

Signed-off-by: Jun Tian <jun.tian@intel.com>