### PR TITLE
Terminate sample app with unrecognized parameters

### DIFF
--- a/Source/App/EbAppConfig.c
+++ b/Source/App/EbAppConfig.c
@@ -1353,6 +1353,7 @@ EB_ERRORTYPE ReadCommandLine(
             printf(" %s ", cmd_copy[cmd_copy_index]);
         }
         printf("\n\n");
+        return_error = EB_ErrorBadParameter;
     }
 
     if (return_error == EB_ErrorNone){


### PR DESCRIPTION
Check spelling of parameters start with "-".
Terminate execution with unrecognized parameters.

Signed-off-by: Jun Tian <jun.tian@intel.com>