### PR TITLE
Build: Update cmake file to support normal build/install in Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,30 @@ set(project_name "svt-hevc")
 
 project(${project_name} C ASM_NASM)
 
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+message(STATUS "CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}")
+
+if(NOT CMAKE_C_COMPILER)
+    set(CMAKE_C_COMPILER gcc)
+endif()
+message(STATUS "CMAKE_C_COMPILER = ${CMAKE_C_COMPILER}")
+
+if(NOT MAKE_ASM_NASM_COMPILER)
+    set(CMAKE_ASM_NASM_COMPILER yasm)
+endif()
+message(STATUS "CMAKE_ASM_NASM_COMPILER = ${CMAKE_ASM_NASM_COMPILER}")
+
+if(NOT DEFINED CMAKE_INSTALL_PREFIX OR CMAKE_INSTALL_PREFIX STREQUAL "")
+    set(CMAKE_INSTALL_PREFIX "/usr/local" CACHE PATH "..." FORCE)
+endif()
+message(STATUS "CMAKE_INSTALL_PREFIX = ${CMAKE_INSTALL_PREFIX}")
+
+if(NOT DEFINED SVT_HEVC_VERSION OR SVT_HEVC_VERSION STREQUAL "")
+    set(SVT_HEVC_VERSION "1.0.0")
+endif()
+
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/bin)
@@ -44,3 +68,18 @@ endif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 add_subdirectory (Source/Lib)
 add_subdirectory (Source/App)
 add_subdirectory (Source/SimpleApp)
+
+# install libsvt.pc
+if(UNIX)
+    include(FindPkgConfig QUIET)
+    if(PKG_CONFIG_FOUND)
+        configure_file("libsvt.pc.in" "libsvt.pc" @ONLY)
+        install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libsvt.pc" DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig")
+    endif()
+endif()
+
+# install headers and libs
+install(FILES ${CMAKE_SOURCE_DIR}/Source/API/EbApi.h DESTINATION include)
+install(FILES ${CMAKE_SOURCE_DIR}/Source/API/EbErrorCodes.h DESTINATION include)
+install(FILES ${CMAKE_SOURCE_DIR}/Source/API/EbTime.h DESTINATION include)
+install(FILES "${CMAKE_SOURCE_DIR}/Bin/${CMAKE_BUILD_TYPE}/libSvtHevcEnc.so" DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/")

--- a/Source/App/CMakeLists.txt
+++ b/Source/App/CMakeLists.txt
@@ -32,7 +32,7 @@ add_executable (SvtHevcEncApp
 if (UNIX)
 
 	# Configure the RPATH to allow relative runtime linking	
-	INSTALL(TARGETS SvtHevcEncApp RUNTIME DESTINATION ".:\$ORIGIN/../lib:\$ORIGIN/")
+	INSTALL(TARGETS SvtHevcEncApp RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin/")
 
 
 

--- a/Source/SimpleApp/CMakeLists.txt
+++ b/Source/SimpleApp/CMakeLists.txt
@@ -27,7 +27,7 @@ add_executable (SvtHevcEncSimpleApp
 if (UNIX)
 
 	# Configure the RPATH to allow relative runtime linking	
-	INSTALL(TARGETS SvtHevcEncSimpleApp RUNTIME DESTINATION ".:\$ORIGIN/../lib:\$ORIGIN/")
+	INSTALL(TARGETS SvtHevcEncSimpleApp RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin/")
 
 	# Link the Encoder App
 	target_link_libraries (SvtHevcEncSimpleApp

--- a/libsvt.pc.in
+++ b/libsvt.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: svt
+Description: SVT (Scalable Video Technology) for HEVC encoder library
+Version: @SVT_HEVC_VERSION@
+Libs: -L${libdir} -lSvtHevcEnc -lm -ldl -lpthread
+Libs.private:
+Cflags: -I${includedir}


### PR DESCRIPTION
Add pkg-config file support and support make install like normal
build/install with CMake style. After this check, we don't need
to exec the manual install like ffmpeg_plugin.

Signed-off-by: Jun Zhao <jun.zhao@intel.com>