### PR TITLE
CMakeLists.txt improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 2.8)
 set(project_name "svt-hevc")
 
 project(${project_name} C ASM_NASM)

--- a/Source/Lib/ASM_AVX2/CMakeLists.txt
+++ b/Source/Lib/ASM_AVX2/CMakeLists.txt
@@ -34,7 +34,7 @@ else()
 
 endif()
 
-add_library(ASM_AVX2
+add_library(ASM_AVX2 STATIC
     EbCombinedAveragingSAD_Intrinsic_AVX2.h
     EbCombinedAveragingSAD_Intrinsic_AVX512.h
     EbComputeSAD_AVX2.h

--- a/Source/Lib/ASM_SSE2/CMakeLists.txt
+++ b/Source/Lib/ASM_SSE2/CMakeLists.txt
@@ -12,7 +12,7 @@ include_directories (${PROJECT_SOURCE_DIR}/Source/Lib/C_DEFAULT/)
 include_directories (${PROJECT_SOURCE_DIR}/Source/Lib/ASM_SSE2/)
 
 # Utility Source Files
-add_library(ASM_SSE2
+add_library(ASM_SSE2 STATIC
     EbAvcStyleMcp_SSE2.h
     EbComputeMean_SSE2.h
     EbComputeSAD_SSE2.h

--- a/Source/Lib/ASM_SSE4_1/CMakeLists.txt
+++ b/Source/Lib/ASM_SSE4_1/CMakeLists.txt
@@ -15,7 +15,7 @@ include_directories (${PROJECT_SOURCE_DIR}/Source/Lib/ASM_SSE4_1/)
 include_directories (${PROJECT_SOURCE_DIR}/Source/Lib/ASM_AVX2/)
 
 # Utility Source Files
-add_library(ASM_SSE4_1
+add_library(ASM_SSE4_1 STATIC
     EbIntraPrediction_SSE4_1.h
     EbPictureOperators_SSE4_1.h
     EbTransforms_SSE4_1.h

--- a/Source/Lib/ASM_SSSE3/CMakeLists.txt
+++ b/Source/Lib/ASM_SSSE3/CMakeLists.txt
@@ -16,7 +16,7 @@ include_directories (${PROJECT_SOURCE_DIR}/Source/Lib/ASM_SSE4_1/)
 include_directories (${PROJECT_SOURCE_DIR}/Source/Lib/ASM_AVX2/)
 
 # Utility Source Files
-add_library(ASM_SSSE3
+add_library(ASM_SSSE3 STATIC
     EbAvcStyleMcp_SSSE3.h
     EbDeblockingFilter_SSSE3.h
     EbIntraPrediction_SSSE3.h

--- a/Source/Lib/C_DEFAULT/CMakeLists.txt
+++ b/Source/Lib/C_DEFAULT/CMakeLists.txt
@@ -11,7 +11,7 @@ include_directories (${PROJECT_SOURCE_DIR}/Source/Lib/Codec/)
 include_directories (${PROJECT_SOURCE_DIR}/Source/Lib/C_DEFAULT/)
 
 # Utility Source Files
-add_library(C_DEFAULT
+add_library(C_DEFAULT STATIC
     EbAvcStyleMcp_C.h
     EbComputeMean_C.h
     EbComputeSAD_C.h

--- a/Source/Lib/Codec/CMakeLists.txt
+++ b/Source/Lib/Codec/CMakeLists.txt
@@ -196,5 +196,4 @@ endif()
 configure_file(../pkg-config.pc.in ${CMAKE_BINARY_DIR}/SvtHevcEnc.pc @ONLY)
 install(FILES ${CMAKE_BINARY_DIR}/SvtHevcEnc.pc DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 install(TARGETS SvtHevcEnc DESTINATION "${CMAKE_INSTALL_LIBDIR}")
-install(DIRECTORY ../../API/ DESTINATION include
-        FILES_MATCHING PATTERN "*.h")
+install(DIRECTORY ../../API/ DESTINATION "${CMAKE_INSTALL_PREFIX}/include/svt-hevc" FILES_MATCHING PATTERN "*.h")

--- a/Source/Lib/pkg-config.pc.in
+++ b/Source/Lib/pkg-config.pc.in
@@ -1,5 +1,5 @@
-+includedir=@CMAKE_INSTALL_PREFIX@/include/svt-hevc
-+libdir=@CMAKE_INSTALL_LIBDIR@
+includedir=@CMAKE_INSTALL_PREFIX@/include/svt-hevc
+libdir=@CMAKE_INSTALL_LIBDIR@
 
 Name: SvtHevcEnc
 Description: SVT (Scalable Video Technology) for HEVC encoder library

--- a/Source/Lib/pkg-config.pc.in
+++ b/Source/Lib/pkg-config.pc.in
@@ -1,5 +1,5 @@
-includedir=@CMAKE_INSTALL_PREFIX@/include
-libdir=@CMAKE_INSTALL_PREFIX@/lib
++includedir=@CMAKE_INSTALL_PREFIX@/include/svt-hevc
++libdir=@CMAKE_INSTALL_LIBDIR@
 
 Name: SvtHevcEnc
 Description: SVT (Scalable Video Technology) for HEVC encoder library


### PR DESCRIPTION
(1)	Installed include files under include/svt-hevc to avoid polluting the include directories. This is needed if you want to install to system path: /usr/include.
(2)	Reduced cmake minimum version to v2.8 (to make CentOS happy.)
(3)	Added STATIC to libraries so that –DBUILD_SHARED_LIBS=ON does not cause trouble.
(4)	Fixed binaries and pkg-config files installing to the proper system path (specified by CMAKE_INSTALL_LIBDIR.)

Tested under CentOS 7.5,  Ubuntu 16.04 and Ubuntu 18.04.