### PR TITLE
set absolute path to libdir in pkg-config config

### DIFF
--- a/Source/Lib/Codec/CMakeLists.txt
+++ b/Source/Lib/Codec/CMakeLists.txt
@@ -202,7 +202,11 @@ target_link_libraries(SvtHevcEnc
 	ASM_AVX2)
 
 if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
-    set(CMAKE_INSTALL_LIBDIR lib)
+    set(CMAKE_INSTALL_LIBDIR "lib")
+endif()
+
+if(NOT DEFINED CMAKE_INSTALL_INCLUDEDIR)
+    set(CMAKE_INSTALL_INCLUDEDIR "include/svt-hevc")
 endif()
 
 configure_file(../pkg-config.pc.in ${CMAKE_BINARY_DIR}/SvtHevcEnc.pc @ONLY)

--- a/Source/Lib/pkg-config.pc.in
+++ b/Source/Lib/pkg-config.pc.in
@@ -1,5 +1,6 @@
-includedir=@CMAKE_INSTALL_PREFIX@/include/svt-hevc
-libdir=@CMAKE_INSTALL_LIBDIR@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 
 Name: SvtHevcEnc
 Description: SVT (Scalable Video Technology) for HEVC encoder library


### PR DESCRIPTION
The lib include path was incorrect on Windows since 85ecb0d4870430dcd268238c0bc4262cbe724a88
This change fixes it.