### PR TITLE
Fix bitstream mismatch for un-ref B/P frames

### DIFF
--- a/Source/Lib/Codec/EbCodingLoop.c
+++ b/Source/Lib/Codec/EbCodingLoop.c
@@ -3464,6 +3464,7 @@ EB_EXTERN void EncodePass(
         sequenceControlSetPtr->staticConfig.reconEnabled;
 
     dlfEnableFlag = contextPtr->allowEncDecMismatch ? EB_FALSE : dlfEnableFlag;
+    pictureControlSetPtr->sliceDlfDisableFlag = !dlfEnableFlag;
 
     const EB_BOOL isIntraLCU = contextPtr->mdContext->limitIntra ? isIntraPresent(lcuPtr) : EB_TRUE;
 

--- a/Source/Lib/Codec/EbEntropyCoding.c
+++ b/Source/Lib/Codec/EbEntropyCoding.c
@@ -6211,7 +6211,7 @@ static void CodeSliceHeader(
 
 	SequenceControlSet_t     *sequenceControlSetPtr = (SequenceControlSet_t*)pcsPtr->sequenceControlSetWrapperPtr->objectPtr;
 
-	EB_BOOL disableDlfFlag = sequenceControlSetPtr->staticConfig.disableDlfFlag;
+    EB_BOOL disableDlfFlag = pcsPtr->sliceDlfDisableFlag;
 
 	EB_U32 sliceType = (pcsPtr->ParentPcsPtr->idrFlag == EB_TRUE) ? EB_I_PICTURE : pcsPtr->sliceType;
 

--- a/Source/Lib/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Codec/EbPictureControlSet.h
@@ -265,6 +265,7 @@ typedef struct PictureControlSet_s
 
 	struct PictureParentControlSet_s     *ParentPcsPtr;//The parent of this PCS.
 	EbObjectWrapper_t                    *PictureParentControlSetWrapperPtr;
+    EB_BOOL                               sliceDlfDisableFlag;
 	EB_S8                                 betaOffset;
 	EB_S8                                 tcOffset;
 


### PR DESCRIPTION
Even if we enable DLF at application level, no DLF will be done for B/P
frames which are not used as a reference. However in previous
implementation slice_deblocking_filter_disabled_flag is not set
correctly for such case

Signed-off-by: Jing Li <jing.b.li@intel.com>