### PR TITLE
Fix conformance error for rbsp_stop_one_bit

### DIFF
--- a/Source/Lib/Codec/EbEntropyCoding.c
+++ b/Source/Lib/Codec/EbEntropyCoding.c
@@ -5290,44 +5290,45 @@ static void CodeVPS(
         bitstreamPtr,
         scsPtr->staticConfig.fpsInVps == 1 ? EB_TRUE : EB_FALSE);
 
-    if (scsPtr->staticConfig.frameRateDenominator != 0 && scsPtr->staticConfig.frameRateNumerator != 0) {
+    if (scsPtr->staticConfig.fpsInVps == 1) {
+        if (scsPtr->staticConfig.frameRateDenominator != 0 && scsPtr->staticConfig.frameRateNumerator != 0) {
 
-        // vps_num_units_in_tick
-        WriteCodeCavlc(
-            bitstreamPtr,
-            scsPtr->staticConfig.frameRateNumerator,
-            32);
+            // vps_num_units_in_tick
+            WriteCodeCavlc(
+                    bitstreamPtr,
+                    scsPtr->staticConfig.frameRateNumerator,
+                    32);
 
-        // vps_time_scale
-        WriteCodeCavlc(
-            bitstreamPtr,
-            scsPtr->staticConfig.frameRateDenominator,
-            32);
+            // vps_time_scale
+            WriteCodeCavlc(
+                    bitstreamPtr,
+                    scsPtr->staticConfig.frameRateDenominator,
+                    32);
+        }
+        else {
+            // vps_num_units_in_tick
+            WriteCodeCavlc(
+                    bitstreamPtr,
+                    scsPtr->frameRate > 1000 ? scsPtr->frameRate : scsPtr->frameRate << 16,
+                    32);
+
+            // vps_time_scale
+            WriteCodeCavlc(
+                    bitstreamPtr,
+                    1 << 16,
+                    32);
+        }
+
+        // vps_poc_proportional_to_timing_flag 
+        WriteFlagCavlc(
+                bitstreamPtr,
+                0);
+
+        // vps_num_hrd_parameters 
+        WriteUvlc(
+                bitstreamPtr,
+                0);
     }
-    else {
-        // vps_num_units_in_tick
-        WriteCodeCavlc(
-            bitstreamPtr,
-            scsPtr->frameRate > 1000 ? scsPtr->frameRate : scsPtr->frameRate << 16,
-            32);
-
-        // vps_time_scale
-        WriteCodeCavlc(
-            bitstreamPtr,
-            1 << 16,
-            32);
-    }
-
-    // vps_poc_proportional_to_timing_flag 
-    WriteFlagCavlc(
-        bitstreamPtr,
-        0);
-
-    // vps_num_hrd_parameters 
-    WriteUvlc(
-        bitstreamPtr,
-        0);
-
 
 
 	// "vps_extension_flag"


### PR DESCRIPTION
It's caused by vps_timing_info_present_flag. vps timing info should be
written to bitstream only if this _present flag is set to 1

Signed-off-by: Jing Li <jing.b.li@intel.com>