### PR TITLE
Abort encoding after pressing ^C twice on TTY

### DIFF
--- a/Source/App/EbAppMain.c
+++ b/Source/App/EbAppMain.c
@@ -56,6 +56,9 @@ volatile int32_t keepRunning = 1;
 void EventHandler(int32_t dummy) {
     (void)dummy;
     keepRunning = 0;
+
+    // restore default signal handler
+    signal(SIGINT, SIG_DFL);
 }
 
 void AssignAppThreadGroup(uint8_t targetSocket) {


### PR DESCRIPTION
Copied from
https://github.com/OpenVisualCloud/SVT-VP9/blob/e92a57c099c3accd68bbfba560d7f2aebc450acd/Source/App/EbAppMain.c#L61-L62
https://github.com/OpenVisualCloud/SVT-AV1/blob/df11eb05714700c84c77bc5958371719f9748821/Source/App/EbAppMain.c#L61-L62

Ctrl+C once stops encoding, Ctrl+C twice aborts immediately. This fixes the second case.
```
$ SvtHevcEncApp -encMode 0 -q 26 -i foo.yuv -w 1280 -h 720 -fps 24 -b foo.ivf
-------------------------------------------
SVT-HEVC Encoder
SVT [version]:  SVT-HEVC Encoder Lib v1.3.0
SVT [build]  :  GCC 4.2.1        64 bit
LIB Build date: Feb 24 2019 06:19:28
-------------------------------------------
Number of logical cores available: 8
Number of PPCS 53
-------------------------------------------
SVT [config]: Main10 Profile    Tier (auto)     Level (auto)
SVT [config]: EncoderMode / LatencyMode / Tune                                  : 0 / 0 / 1
SVT [config]: EncoderBitDepth / CompressedTenBitFormat                          : 8 / 0
SVT [config]: SourceWidth / SourceHeight                                        : 1280 / 720
SVT [config]: FrameRate / Gop Size                                              : 24 / 24
SVT [config]: HierarchicalLevels / BaseLayerSwitchMode / PredStructure          : 3 / 0 / 2
SVT [config]: BRC Mode / QP  / LookaheadDistance / SceneChange                  : CQP / 26 / 17 / 1
-------------------------------------------

SVT [WARNING] Elevated privileges required to run with real-time policies! Check Linux Best Known Configuration in User Guide to run application in real-time without elevated privileges!

Encoding          12^C^C^C^C^C^C^C^             15^C^C^C^       16^C^C^C^C^C^C^C^C^C^C^       21^C^C^C^C^C^C^C^
      2       27^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^       28^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^       29^
  31^C^C^C^C^C^C^C^C^C^C^C^C^       32^C^C^C^C^C^       35^C^C^C^       36^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^       37^       73
SUMMARY --------------------------------- Channel 1  --------------------------------
Total Frames            Frame Rate              Byte Count              Bitrate
          73            24.00 fps                   125878              331.08 kbps


Channel 1 Encoding Interrupted
Encoder finished
```
