### PR TITLE
[ffmpeg_plugin] Sync pkg-config include directory

### DIFF
--- a/Source/Lib/Codec/CMakeLists.txt
+++ b/Source/Lib/Codec/CMakeLists.txt
@@ -206,7 +206,7 @@ if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
 endif()
 
 if(NOT DEFINED CMAKE_INSTALL_INCLUDEDIR)
-    set(CMAKE_INSTALL_INCLUDEDIR "include/svt-hevc")
+    set(CMAKE_INSTALL_INCLUDEDIR "include")
 endif()
 
 configure_file(../pkg-config.pc.in ${CMAKE_BINARY_DIR}/SvtHevcEnc.pc @ONLY)


### PR DESCRIPTION
pkg-config is supposed to provide all the flags required to build against this library. Regressed by #111.
x265 with `-DENABLE_SVT_HEVC=ON` still builds fine because it uses [CMake module](https://github.com/videolan/x265/blob/master/source/cmake/Findsvthevc.cmake) rather than pkg-config to find a directory that contains EbApi.h.
