### PR TITLE
FFmpeg-Plugin: Revert the header file names' change

### DIFF
--- a/ffmpeg_plugin/0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
+++ b/ffmpeg_plugin/0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
@@ -71,7 +71,7 @@ index a70c5f9..06d5e8e 100755
  enabled libssh            && require_pkg_config libssh libssh libssh/sftp.h sftp_init
  enabled libspeex          && require_pkg_config libspeex speex speex/speex.h speex_decoder_init
  enabled libsrt            && require_pkg_config libsrt "srt >= 1.3.0" srt/srt.h srt_socket
-+enabled libsvthevc        && require_pkg_config libsvthevc SvtHevcEnc svt-hevc/EbApi.h EbInitHandle
++enabled libsvthevc        && require_pkg_config libsvthevc SvtHevcEnc EbApi.h EbInitHandle
  enabled libtensorflow     && require libtensorflow tensorflow/c/c_api.h TF_Version -ltensorflow
  enabled libtesseract      && require_pkg_config libtesseract tesseract tesseract/capi.h TessBaseAPICreate
  enabled libtheora         && require libtheora theora/theoraenc.h th_info_init -ltheoraenc -ltheoradec -logg
@@ -127,9 +127,9 @@ index 0000000..533d308
 +* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 +*/
 +
-+#include "svt-hevc/EbErrorCodes.h"
-+#include "svt-hevc/EbTime.h"
-+#include "svt-hevc/EbApi.h"
++#include "EbErrorCodes.h"
++#include "EbTime.h"
++#include "EbApi.h"
 +
 +#include "libavutil/common.h"
 +#include "libavutil/frame.h"


### PR DESCRIPTION
SVT AV1 has changed the duplicated header file names, so I am reverting the change in SVT HEVC.